### PR TITLE
Add 404 to be packed as b64encoded exception

### DIFF
--- a/django_zappa/handler.py
+++ b/django_zappa/handler.py
@@ -100,7 +100,7 @@ def lambda_handler(event, context, settings_name="zappa_settings"):
         # as an error to match our APIGW regex.
         # The DOCTYPE ensures that the page still renders in the browser.
         exception = None
-        if response.status_code in [400, 401, 403, 500]:
+        if response.status_code in [400, 401, 403, 404, 500]:
             content = response.content
             content = "<!DOCTYPE html>" + str(response.status_code) + response.content
             b64_content = base64.b64encode(content)


### PR DESCRIPTION
404 is missing from the list of status codes that trigger a base 64 encoded exception which is matched in the gateway. As a result the underlying app cannot raise a 404 all the way through the gateway to the client.

Adding 404 fixes this.