### PR TITLE
Readme - Add INSTALLED_APPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Notice that each environment defines a path to a settings file. This file will b
 
 Since Zappa requirements are called from a bundled version of your local environment and not from pip, and because we have no way to determine what platform our Zappa handler will be executing on, we need to make sure that we only use portable packages. So, instead of using the default MySQL engine, we will instead need to use _mysql-python-connector_. 
 
-That means your app's settings file will need an entry that looks like something this (notice the Engine field):
+That means your app's settings file will need an entry that looks something like this (notice the Engine field):
 
 ```python
 DATABASES = {

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ MIDDLEWARE_CLASSES = (
 )
 ```
 
+#### Installed Apps
+
+ Django-Zappa adds commands to the django manage.py script to make deploying and
+ updating your application easy. You will need to add `django_zappa` to your
+ installed apps in order to enable this functionality.
+
+ ```python
+ INSTALLED_APPS = [
+     ...
+
+     'django_zappa',
+ ]
+ ```
+
+
 ## Basic Usage
 
 #### Initial Deployments


### PR DESCRIPTION
django_zappa must be added as an installed app for django to pick up its
custom commands for manage.py