### PR TITLE
Fixes #13 -- Adds support for various 3** HTTP respones

### DIFF
--- a/django_zappa/handler.py
+++ b/django_zappa/handler.py
@@ -107,7 +107,7 @@ def lambda_handler(event, context, settings_name="zappa_settings"):
             exception = (b64_content)
         # Internal are changed to become relative redirects
         # so they still work for apps on raw APIGW and on a domain.
-        elif response.status_code in [301, 302]:
+        elif response.status_code[0] == 3 and response.has_header('Location'):
             location = returnme['Location']
             location = '/' + location.replace("http://zappa/", "")
             exception = location


### PR DESCRIPTION
Adds support for 301 - 306 HTTP responses.
307 and 308 want you to use the same METHOD as the original request.
This is something your javascript code doesn't do yet.