### PR TITLE
Fixes #13 -- Adds support for various 3** HTTP respones

### DIFF
--- a/django_zappa/handler.py
+++ b/django_zappa/handler.py
@@ -29,7 +29,7 @@ from zappa.wsgi import create_wsgi_request, common_log
 def lambda_handler(event, context, settings_name="zappa_settings"):
     """
     An AWS Lambda function which parses specific API Gateway input into a WSGI request,
-    feeds it to Django, procceses the Django response, and returns that 
+    feeds it to Django, procceses the Django response, and returns that
     back to the API Gateway.
 
     """
@@ -107,7 +107,7 @@ def lambda_handler(event, context, settings_name="zappa_settings"):
             exception = (b64_content)
         # Internal are changed to become relative redirects
         # so they still work for apps on raw APIGW and on a domain.
-        elif response.status_code in [301, 302]:
+        elif 300 <= response.status_code < 400 and response.has_header('Location'):
             location = returnme['Location']
             location = '/' + location.replace("http://zappa/", "")
             exception = location


### PR DESCRIPTION
Adds support for 301 - 306 HTTP responses.
307 and 308 want you to use the same METHOD as the original request.
This is something your javascript code doesn't do yet.

**EDIT:** I switcht it to integer checking.

I honestly don't know how to write tests for all this.
That might be something you want elaborate on in the contributing
guide.