### PR TITLE
aws don't like underscores in names

### DIFF
--- a/django_zappa/management/commands/zappa_command.py
+++ b/django_zappa/management/commands/zappa_command.py
@@ -62,7 +62,7 @@ class ZappaCommand(BaseCommand):
             self.api_stage = options['environment'][0]
         else:
             self.api_stage = options['environment']
-        self.lambda_name = self.project_name + '-' + self.api_stage
+        self.lambda_name = (self.project_name + '-' + self.api_stage).replace("_","-")
         if self.api_stage not in self.zappa_settings.keys():
             print("Please make sure that the environment '" + self.api_stage +
                   "' is defined in your ZAPPA_SETTINGS in your settings file before deploying.")


### PR DESCRIPTION
It returns AccessDeniedException, though user has all required permissions.

`botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the UpdateFunctionCode operation: User: arn:aws:iam::883014317556:user/dmitry.smal.zappa is not authorized to perform: lambda:UpdateFunctionCode on resource: arn:aws:lambda:us-east-1:883014317556:function:app_portal-dev
`