### PR TITLE
Upload Command Fixes & Deploy/Undeploy event flag for Update/Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ You can watch the logs of a deployment by calling the 'tail' management command.
 
     $ python manage.py tail production
 
+#### Deploying & Updating Scheduled Events
+
+You can deploy and update scheduled events alongside the deploy or update of the main
+application by passing the `--schedule` flag.
+
+**Note**: your previous events will not be removed and updated when you run this
+flag and you will end up with duplicates if you do not run with `--unschedule` as
+well to remove previous tasks.
+
 ## Advanced Usage
 
 There are other settings that you can define in your ZAPPA_SETTINGS
@@ -128,6 +137,10 @@ ZAPPA_SETTINGS = {
         'settings_file': '~/Projects/MyApp/settings/dev_settings.py', # Server side settings file location or use the s3://mybucketname:path/to/my/settings.py format,
         'touch': False, # GET the production URL upon initial deployment (default True)
         'use_precompiled_packages': True, # If possible, use C-extension packages which have been pre-compiled for AWS Lambda
+        'events': [{
+            'function': 'your_module.your_function', // The function to execute
+            'expression': 'rate(1 minute)' // When to execute it (in cron or rate format)
+        }],
         'vpc_config': { # Optional VPC configuration for Lambda function
             'SubnetIds': [ 'subnet-12345678' ], # Note: not all availability zones support Lambda!
             'SecurityGroupIds': [ 'sg-12345678' ]

--- a/django_zappa/management/commands/deploy.py
+++ b/django_zappa/management/commands/deploy.py
@@ -19,6 +19,18 @@ class Command(ZappaCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('environment', nargs='+', type=str)
+        parser.add_argument('--schedule',
+            dest='schedule',
+            action='store_true',
+            default=False,
+            help='Schedule Lambda Events'
+        )
+        parser.add_argument('--unschedule',
+            dest='unschedule',
+            action='store_true',
+            default=False,
+            help='UnSchedule(Remove) Lambda Events'
+        )
 
     def handle(self, *args, **options):  # NoQA
         """
@@ -79,4 +91,14 @@ class Command(ZappaCommand):
 
         print("Your Zappa deployment is live!: " + endpoint_url)
 
-        return
+        events = self.zappa_settings[self.api_stage].get('events')
+
+        if options['unschedule'] and events:
+            self.zappa.unschedule_events(lambda_arn, self.lambda_name, events)
+        elif options['unschedule'] and not events:
+            print("No Events to Unschedule")
+
+        if options['schedule'] and events:
+            self.zappa.schedule_events(lambda_arn, self.lambda_name, events)
+        elif options['schedule'] and not events:
+            print("No Events to Schedule")

--- a/django_zappa/management/commands/zappa_command.py
+++ b/django_zappa/management/commands/zappa_command.py
@@ -60,11 +60,14 @@ class ZappaCommand(BaseCommand):
         self.zappa_settings = settings.ZAPPA_SETTINGS
 
         # Set your configuration
-        self.project_name = os.path.abspath(settings.BASE_DIR).split(os.sep)[-1]
         if type(options['environment']) == list:
             self.api_stage = options['environment'][0]
         else:
             self.api_stage = options['environment']
+        if self.zappa_settings[self.api_stage].get('project_name'):
+            self.project_name = self.zappa_settings[self.api_stage]['project_name']
+        else:
+            self.project_name = os.path.abspath(settings.BASE_DIR).split(os.sep)[-1]
         self.lambda_name = slugify(self.project_name + '-' + self.api_stage).replace("_","-")
         if self.api_stage not in self.zappa_settings.keys():
             print("Please make sure that the environment '" + self.api_stage +

--- a/django_zappa/management/commands/zappa_command.py
+++ b/django_zappa/management/commands/zappa_command.py
@@ -176,12 +176,11 @@ class ZappaCommand(BaseCommand):
             inspect.getfile(inspect.currentframe())))
         handler_file = os.sep.join(current_file.split(os.sep)[
                                    0:-2]) + os.sep + 'handler.py'
-
-        exclude = ['static', 'media']
+        exclude = self.zappa_settings[self.api_stage].get('exclude', []) + ['static', 'media']
         self.zip_path = self.zappa.create_lambda_zip(
                 self.lambda_name,
                 handler_file=handler_file,
-                use_precompiled_packages=self.zappa_settings.get('use_precompiled_packages', True),
+                use_precompiled_packages=self.zappa_settings[self.api_stage].get('use_precompiled_packages', True),
                 exclude=exclude
             )
 


### PR DESCRIPTION
- Adds data from `exclude` key in settings to current exclusion list.
- Fixes issue with setting for `use_precompiled_packages` not being passed to `zappa.create_lambda_zip` properly.
- Adding `--unschedule` and `--schedule` flags on update/deploy commands that will update AWS for the scheduled events defined in the `events` key of the stage's settings.
- Adding handler for scheduled tasks.
- Logging error when an unrecognized event format falls through in handler.