### PR TITLE
[Doppins] Upgrade dependency lambda-packages to ==0.7.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ flake8==3.0.0
 futures==3.0.5            # via zappa
 isort==4.2.5
 jmespath==0.9.0           # via boto3, botocore, zappa
-lambda-packages==0.6.1    # via zappa 
+lambda-packages==0.7.0    # via zappa 
 mccabe==0.5.0             # via flake8
 nose==1.3.7               # via zappa
 pep257==0.7.0


### PR DESCRIPTION
Hi!

A new version was just released of `lambda-packages`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lambda-packages from `==0.6.1` to `==0.7.0`

